### PR TITLE
2 additive schwarz

### DIFF
--- a/include/pda-schwarz/schwarz.hpp
+++ b/include/pda-schwarz/schwarz.hpp
@@ -533,7 +533,8 @@ public:
         double time,
         const double rel_err_tol,
         const double abs_err_tol,
-        const int convergeStepMax)
+        const int convergeStepMax,
+        const bool additive)
     {
 
         const auto & tiling = *m_tiling;
@@ -587,8 +588,10 @@ public:
 
                 } // domain loop
 
-                // broadcast boundary conditions
-                broadcast_bcState(domIdx);
+                // broadcast boundary conditions immediately for multiplicative Schwarz
+                if (!additive) {
+                    broadcast_bcState(domIdx);
+                }
 
             }
 
@@ -605,6 +608,13 @@ public:
             cout << "Average rel err: " << rel_err << endl;
             if ((rel_err < rel_err_tol) || (abs_err < abs_err_tol)) {
                 break;
+            }
+
+            // broadcast boundary conditions after domain cycle for additive Schwarz
+            if (additive) {
+                for (int domIdx = 0; domIdx < ndomains; ++domIdx) {
+                    broadcast_bcState(domIdx);
+                }
             }
 
             convergeStep++;

--- a/tests_cpp/eigen_2d_euler_riemann_implicit_schwarz/main.cc
+++ b/tests_cpp/eigen_2d_euler_riemann_implicit_schwarz/main.cc
@@ -59,7 +59,8 @@ int main()
             time,
             rel_err_tol,
             abs_err_tol,
-            convergeStepMax
+            convergeStepMax,
+            false
         );
 
         time += decomp.m_dtMax;

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/main.cc
@@ -71,7 +71,8 @@ int main()
             time,
             rel_err_tol,
             abs_err_tol,
-            convergeStepMax
+            convergeStepMax,
+            false
         );
 
         time += decomp.m_dtMax;

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/main.cc
@@ -59,7 +59,8 @@ int main()
             time,
             rel_err_tol,
             abs_err_tol,
-            convergeStepMax
+            convergeStepMax,
+            false
         );
 
         time += decomp.m_dtMax;


### PR DESCRIPTION
Implements additive Schwarz, just requires passing a bool to `calc_controller_step` indicating whether the step should be additive. Doing it this way instead of as a parameter in the `SchwarzDecomp` since I can see a modification where a multiplicative step is taken if additive is converging poorly.