### PR TITLE
Runtime statistics

### DIFF
--- a/tests_cpp/eigen_2d_euler_riemann_implicit/compare.py
+++ b/tests_cpp/eigen_2d_euler_riemann_implicit/compare.py
@@ -1,37 +1,48 @@
-
+import struct
 import numpy as np
 
-gamma = (5.+2.)/5.
+gamma = (5. + 2.) / 5.
 
 def computePressure(rho, u, v, E):
-  vel = u**2 + v**2
-  return (gamma - 1.) * (E - rho*vel*0.5)
+    vel = u**2 + v**2
+    return (gamma - 1.) * (E - rho * vel * 0.5)
 
 if __name__== "__main__":
-  nx=50
-  ny=50
-  fomTotDofs = nx*ny*4
+    nx = 50
+    ny = 50
+    fomTotDofs = nx * ny * 4
 
-  D = np.fromfile("riemann2d_solution.bin")
-  nt = int(np.size(D)/fomTotDofs)
-  D = np.reshape(D, (nt, fomTotDofs))
-  D = D[-1, :]
-  D = np.reshape(D, (nx*ny, 4))
-  rho = D[:,0]
-  u   = D[:,1]/rho
-  v   = D[:,2]/rho
-  p   = computePressure(rho, u, v, D[:,3])
-  np.savetxt("rho.txt", rho)
-  np.savetxt("p.txt", p)
+    D = np.fromfile("riemann2d_solution.bin")
+    nt = int(np.size(D) / fomTotDofs)
+    D = np.reshape(D, (nt, fomTotDofs))
+    D = D[-1, :]
+    D = np.reshape(D, (nx * ny, 4))
+    rho = D[:,0]
+    u   = D[:,1] / rho
+    v   = D[:,2] / rho
+    p   = computePressure(rho, u, v, D[:,3])
+    np.savetxt("rho.txt", rho)
+    np.savetxt("p.txt", p)
 
-  goldR = np.loadtxt("rho_gold.txt")
-  assert(rho.shape == goldR.shape)
-  assert(np.isnan(rho).all() == False)
-  assert(np.isnan(goldR).all() == False)
-  assert(np.allclose(rho, goldR,rtol=1e-10, atol=1e-12))
+    goldR = np.loadtxt("rho_gold.txt")
+    assert rho.shape == goldR.shape
+    assert np.isnan(rho).all() == False
+    assert np.isnan(goldR).all() == False
+    assert np.allclose(rho, goldR, rtol=1e-10, atol=1e-12)
 
-  goldP = np.loadtxt("p_gold.txt")
-  assert(p.shape == goldP.shape)
-  assert(np.isnan(p).all() == False)
-  assert(np.isnan(goldP).all() == False)
-  assert(np.allclose(p, goldP,rtol=1e-10, atol=1e-12))
+    goldP = np.loadtxt("p_gold.txt")
+    assert p.shape == goldP.shape
+    assert np.isnan(p).all() == False
+    assert np.isnan(goldP).all() == False
+    assert np.allclose(p, goldP, rtol=1e-10, atol=1e-12)
+
+    # check runtime file
+    f = open('runtime.bin', 'rb')
+    contents = f.read()
+    assert len(contents) == 24
+    ndomains = struct.unpack('Q', contents[:8])[0]
+    assert ndomains == 1
+    niters = struct.unpack('Q', contents[8:16])[0]
+    assert niters == 1
+    timeval = struct.unpack('d', contents[16:24])[0]
+    assert timeval > 0.0

--- a/tests_cpp/eigen_2d_euler_riemann_implicit/main.cc
+++ b/tests_cpp/eigen_2d_euler_riemann_implicit/main.cc
@@ -3,6 +3,7 @@
 #include "pressio/ode_advancers.hpp"
 #include "pressiodemoapps/euler2d.hpp"
 #include "../observer.hpp"
+#include <chrono>
 
 int main()
 {
@@ -32,11 +33,18 @@ int main()
     NonLinSolver.setStopTolerance(1e-5);
 
     FomObserver<state_t> Obs("riemann2d_solution.bin", 2);
+    RuntimeObserver Obs_run("runtime.bin");
 
     const double tf = 1.0;
     const double dt = 0.005;
     const auto Nsteps = pressio::ode::StepCount(tf/dt);
+
+    auto runtimeStart = std::chrono::high_resolution_clock::now();
     pressio::ode::advance_n_steps(stepperObj, state, 0., dt, Nsteps, Obs, NonLinSolver);
+    auto runtimeEnd = std::chrono::high_resolution_clock::now();
+    auto nsElapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(runtimeEnd - runtimeStart).count();
+    double secElapsed = static_cast<double>(nsElapsed) * 1e-9;
+    Obs_run(secElapsed);
 
     pressio::log::finalize();
     return 0;

--- a/tests_cpp/eigen_2d_euler_riemann_implicit_schwarz/compare.py
+++ b/tests_cpp/eigen_2d_euler_riemann_implicit_schwarz/compare.py
@@ -1,4 +1,4 @@
-
+import struct
 import numpy as np
 
 gamma = (5.+2.)/5.
@@ -8,36 +8,64 @@ def computePressure(rho, u, v, E):
   return (gamma - 1.) * (E - rho*vel*0.5)
 
 if __name__== "__main__":
-  nx=30
-  ny=30
-  fomTotDofs = nx*ny*4
 
-  allclose_rho = []
-  allclose_p   = []
-  for dom_idx in range(4):
-    D = np.fromfile(f"riemann2d_solution_{dom_idx}.bin")
-    nt = int(np.size(D)/fomTotDofs)
-    D = np.reshape(D, (nt, fomTotDofs))
-    D = D[-1, :]
-    D = np.reshape(D, (nx*ny, 4))
-    rho = D[:,0]
-    u   = D[:,1]/rho
-    v   = D[:,2]/rho
-    p   = computePressure(rho, u, v, D[:,3])
-    np.savetxt(f"rho_{dom_idx}.txt", rho)
-    np.savetxt(f"p_{dom_idx}.txt", p)
+    nx = 30
+    ny = 30
+    fomTotDofs = nx * ny * 4
 
-    goldR = np.loadtxt(f"rho_gold_{dom_idx}.txt")
-    assert(rho.shape == goldR.shape)
-    assert(np.isnan(rho).all() == False)
-    assert(np.isnan(goldR).all() == False)
-    allclose_rho.append(np.allclose(rho, goldR,rtol=1e-10, atol=1e-12))
+    allclose_rho = []
+    allclose_p   = []
+    for dom_idx in range(4):
+        D = np.fromfile(f"riemann2d_solution_{dom_idx}.bin")
+        nt = int(np.size(D) / fomTotDofs)
+        D = np.reshape(D, (nt, fomTotDofs))
+        D = D[-1, :]
+        D = np.reshape(D, (nx * ny, 4))
+        rho = D[:, 0]
+        u   = D[:, 1] / rho
+        v   = D[:, 2] / rho
+        p   = computePressure(rho, u, v, D[:,3])
+        np.savetxt(f"rho_{dom_idx}.txt", rho)
+        np.savetxt(f"p_{dom_idx}.txt", p)
 
-    goldP = np.loadtxt(f"p_gold_{dom_idx}.txt")
-    assert(p.shape == goldP.shape)
-    assert(np.isnan(p).all() == False)
-    assert(np.isnan(goldP).all() == False)
-    allclose_p.append(np.allclose(p, goldP,rtol=1e-10, atol=1e-12))
+        goldR = np.loadtxt(f"rho_gold_{dom_idx}.txt")
+        assert rho.shape == goldR.shape
+        assert np.isnan(rho).all() == False
+        assert np.isnan(goldR).all() == False
+        allclose_rho.append(np.allclose(rho, goldR, rtol=1e-10, atol=1e-12))
 
-assert all(allclose_rho)
-assert all(allclose_p)
+        goldP = np.loadtxt(f"p_gold_{dom_idx}.txt")
+        assert p.shape == goldP.shape
+        assert np.isnan(p).all() == False
+        assert np.isnan(goldP).all() == False
+        allclose_p.append(np.allclose(p, goldP, rtol=1e-10, atol=1e-12))
+
+    assert all(allclose_rho)
+    assert all(allclose_p)
+
+    # check runtime file
+    f = open('runtime.bin', 'rb')
+    contents = f.read()
+    nbytes_file = len(contents)
+    assert nbytes_file > 0
+    ndomains = struct.unpack('Q', contents[:8])[0]
+    assert ndomains == 4
+
+    nbytes_read = 8
+    niters = 0
+    while nbytes_read < nbytes_file:
+
+        nsubiters = struct.unpack('Q', contents[nbytes_read:nbytes_read+8])[0]
+        nbytes_read += 8
+        runtime_arr = np.zeros((ndomains, nsubiters), dtype=np.float64)
+
+        for iter_idx in range(nsubiters):
+            runtime_vals = struct.unpack('d'*ndomains, contents[nbytes_read:nbytes_read+8*ndomains])
+            runtime_arr[:, iter_idx] = np.array(runtime_vals, dtype=np.float64)
+            nbytes_read += 8*ndomains
+
+        assert np.amin(runtime_arr) > 0.0
+
+        niters += 1
+
+    assert niters == 200

--- a/tests_cpp/eigen_2d_euler_riemann_implicit_schwarz/main.cc
+++ b/tests_cpp/eigen_2d_euler_riemann_implicit_schwarz/main.cc
@@ -47,6 +47,8 @@ int main()
         obsVec[domIdx](::pressio::ode::StepCount(0), 0.0, decomp.m_subdomainVec[domIdx]->m_state);
     }
 
+    RuntimeObserver obs_time("runtime.bin", (*tiling).count());
+
     // solve
     const int numSteps = tf / decomp.m_dtMax;
     double time = 0.0;
@@ -55,7 +57,7 @@ int main()
         cout << "Step " << outerStep << endl;
 
         // compute contoller step until convergence
-        decomp.calc_controller_step(
+        auto runtimeIter = decomp.calc_controller_step(
             outerStep,
             time,
             rel_err_tol,
@@ -66,13 +68,16 @@ int main()
 
         time += decomp.m_dtMax;
 
-        // output observer
+        // output state observer
         if ((outerStep % obsFreq) == 0) {
             const auto stepWrap = pode::StepCount(outerStep);
             for (int domIdx = 0; domIdx < (*decomp.m_tiling).count(); ++domIdx) {
                 obsVec[domIdx](stepWrap, time, decomp.m_subdomainVec[domIdx]->m_state);
             }
         }
+
+        // runtime observer
+        obs_time(runtimeIter);
 
     }
 

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit/compare.py
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit/compare.py
@@ -1,23 +1,33 @@
-
+import struct
 import numpy as np
-import sys, os
 
 if __name__== "__main__":
-  nx = 50
-  ny = 50
-  fomTotDofs = nx*ny*3
+    nx = 50
+    ny = 50
+    fomTotDofs = nx * ny * 3
 
-  D = np.fromfile("swe_slipWall2d_solution.bin")
-  nt = int(np.size(D)/fomTotDofs)
-  D = np.reshape(D, (nt, fomTotDofs))
-  np.savetxt("solution_full.txt", D.T)
-  D = D[-1, :]
-  D = np.reshape(D, (nx*ny, 3))
-  h = D[:,0]
-  np.savetxt("h.txt", h)
+    D = np.fromfile("swe_slipWall2d_solution.bin")
+    nt = int(np.size(D) / fomTotDofs)
+    D = np.reshape(D, (nt, fomTotDofs))
+    np.savetxt("solution_full.txt", D.T)
+    D = D[-1, :]
+    D = np.reshape(D, (nx*ny, 3))
+    h = D[:, 0]
+    np.savetxt("h.txt", h)
 
-  goldD = np.loadtxt("h_gold.txt")
-  assert(np.allclose(h.shape, goldD.shape))
-  assert(np.isnan(h).all() == False)
-  assert(np.isnan(goldD).all() == False)
-  assert(np.allclose(h, goldD,rtol=1e-10, atol=1e-12))
+    goldD = np.loadtxt("h_gold.txt")
+    assert np.allclose(h.shape, goldD.shape)
+    assert np.isnan(h).all() == False
+    assert np.isnan(goldD).all() == False
+    assert np.allclose(h, goldD, rtol=1e-10, atol=1e-12)
+
+    # check runtime file
+    f = open('runtime.bin', 'rb')
+    contents = f.read()
+    assert len(contents) == 24
+    ndomains = struct.unpack('Q', contents[:8])[0]
+    assert ndomains == 1
+    niters = struct.unpack('Q', contents[8:16])[0]
+    assert niters == 1
+    timeval = struct.unpack('d', contents[16:24])[0]
+    assert timeval > 0.0

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit/main.cc
@@ -3,6 +3,7 @@
 #include "pressio/ode_advancers.hpp"
 #include "pressiodemoapps/swe2d.hpp"
 #include "../observer.hpp"
+#include <chrono>
 
 int main()
 {
@@ -32,11 +33,18 @@ int main()
     NonLinSolver.setStopTolerance(1e-5);
 
     FomObserver<state_t> Obs("swe_slipWall2d_solution.bin", 10);
+    RuntimeObserver Obs_run("runtime.bin");
 
     const double tf = 5;
     const double dt = 0.01;
     const auto Nsteps = pressio::ode::StepCount(tf/dt);
+
+    auto runtimeStart = std::chrono::high_resolution_clock::now();
     pressio::ode::advance_n_steps(stepperObj, state, 0., dt, Nsteps, Obs, NonLinSolver);
+    auto runtimeEnd = std::chrono::high_resolution_clock::now();
+    auto nsElapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(runtimeEnd - runtimeStart).count();
+    double secElapsed = static_cast<double>(nsElapsed) * 1e-9;
+    Obs_run(secElapsed);
 
     pressio::log::finalize();
     return 0;

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms/lspg/compare.py
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms/lspg/compare.py
@@ -1,19 +1,31 @@
 
+import struct
 import numpy as np
-import sys, os
+
 
 if __name__== "__main__":
-  
-  nmodes = 25
 
-  D = np.fromfile("swe_slipWall2d_solution.bin")
-  nt = int(np.size(D)/nmodes)
-  D = np.reshape(D, (nt, nmodes))
-  D = D[-1, :]
-  np.savetxt("reducedState.txt", D)
+    nmodes = 25
 
-  goldD = np.loadtxt("reducedState_gold.txt")
-  assert(np.allclose(D.shape, goldD.shape))
-  assert(np.isnan(D).all() == False)
-  assert(np.isnan(goldD).all() == False)
-  assert(np.allclose(D, goldD,rtol=1e-10, atol=1e-12))
+    D = np.fromfile("swe_slipWall2d_solution.bin")
+    nt = int(np.size(D)/nmodes)
+    D = np.reshape(D, (nt, nmodes))
+    D = D[-1, :]
+    np.savetxt("reducedState.txt", D)
+
+    goldD = np.loadtxt("reducedState_gold.txt")
+    assert(np.allclose(D.shape, goldD.shape))
+    assert(np.isnan(D).all() == False)
+    assert(np.isnan(goldD).all() == False)
+    assert(np.allclose(D, goldD,rtol=1e-10, atol=1e-12))
+
+    # check runtime file
+    f = open('runtime.bin', 'rb')
+    contents = f.read()
+    assert len(contents) == 24
+    ndomains = struct.unpack('Q', contents[:8])[0]
+    assert ndomains == 1
+    niters = struct.unpack('Q', contents[8:16])[0]
+    assert niters == 1
+    timeval = struct.unpack('d', contents[16:24])[0]
+    assert timeval > 0.0

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms/lspg/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms/lspg/main.cc
@@ -3,6 +3,7 @@
 #include "pressio/ode_advancers.hpp"
 #include "pressiodemoapps/swe2d.hpp"
 #include "../../observer.hpp"
+#include <chrono>
 #include "pressio/rom_subspaces.hpp"
 #include "pressio/rom_lspg_unsteady.hpp"
 #include "pda-schwarz/rom_utils.hpp"
@@ -68,11 +69,18 @@ int main()
 
     // observer
     StateObserver Obs("swe_slipWall2d_solution.bin", 10);
+    RuntimeObserver Obs_run("runtime.bin");
 
     const double tf = 5.0;
     const double dt = 0.01;
     const auto Nsteps = pressio::ode::StepCount(tf/dt);
+
+    auto runtimeStart = std::chrono::high_resolution_clock::now();
     pode::advance_n_steps(stepper, reducedState, 0.0, dt, Nsteps, Obs, solver);
+    auto runtimeEnd = std::chrono::high_resolution_clock::now();
+    auto nsElapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(runtimeEnd - runtimeStart).count();
+    double secElapsed = static_cast<double>(nsElapsed) * 1e-9;
+    Obs_run(secElapsed);
 
     pressio::log::finalize();
     return 0;

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/compare.py
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/compare.py
@@ -1,26 +1,53 @@
-
+import struct
 import numpy as np
 
 if __name__== "__main__":
-  nx = 30
-  ny = 30
-  fomTotDofs = nx*ny*3
+    nx = 30
+    ny = 30
+    fomTotDofs = nx * ny * 3
 
-  allclose = []
-  for dom_idx in range(4):
-    D = np.fromfile(f"swe_slipWall2d_solution_{dom_idx}.bin")
-    nt = int(np.size(D)/fomTotDofs)
-    D = np.reshape(D, (nt, fomTotDofs))
-    D = D[-1, :]
-    D = np.reshape(D, (nx*ny, 3))
-    h = D[:,0]
-    np.savetxt(f"h_{dom_idx}.txt", h)
+    allclose = []
+    for dom_idx in range(4):
+        D = np.fromfile(f"swe_slipWall2d_solution_{dom_idx}.bin")
+        nt = int(np.size(D) / fomTotDofs)
+        D = np.reshape(D, (nt, fomTotDofs))
+        D = D[-1, :]
+        D = np.reshape(D, (nx * ny, 3))
+        h = D[:, 0]
+        np.savetxt(f"h_{dom_idx}.txt", h)
 
-    goldD = np.loadtxt(f"h_gold_{dom_idx}.txt")
-    assert(h.shape == goldD.shape)
-    assert(np.isnan(h).all() == False)
-    assert(np.isnan(goldD).all() == False)
-    allclose.append(np.allclose(h, goldD, rtol=1e-10, atol=1e-12))
+        goldD = np.loadtxt(f"h_gold_{dom_idx}.txt")
+        assert h.shape == goldD.shape
+        assert np.isnan(h).all() == False
+        assert np.isnan(goldD).all() == False
+        allclose.append(np.allclose(h, goldD, rtol=1e-10, atol=1e-12))
 
-assert all(allclose)
+    assert all(allclose)
+
+    # check runtime file
+    f = open('runtime.bin', 'rb')
+    contents = f.read()
+    nbytes_file = len(contents)
+    assert nbytes_file > 0
+    ndomains = struct.unpack('Q', contents[:8])[0]
+    assert ndomains == 4
+
+    nbytes_read = 8
+    niters = 0
+    while nbytes_read < nbytes_file:
+
+        nsubiters = struct.unpack('Q', contents[nbytes_read:nbytes_read+8])[0]
+        nbytes_read += 8
+        runtime_arr = np.zeros((ndomains, nsubiters), dtype=np.float64)
+
+        for iter_idx in range(nsubiters):
+            runtime_vals = struct.unpack('d'*ndomains, contents[nbytes_read:nbytes_read+8*ndomains])
+            runtime_arr[:, iter_idx] = np.array(runtime_vals, dtype=np.float64)
+            nbytes_read += 8*ndomains
+
+        assert np.amin(runtime_arr) > 0.0
+
+        niters += 1
+
+    assert niters == 500
 

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/main.cc
@@ -59,6 +59,8 @@ int main()
         obsVec[domIdx](::pressio::ode::StepCount(0), 0.0, decomp.m_subdomainVec[domIdx]->m_state);
     }
 
+    RuntimeObserver obs_time("runtime.bin", (*tiling).count());
+
     // solve
     const int numSteps = tf / decomp.m_dtMax;
     double time = 0.0;
@@ -67,7 +69,7 @@ int main()
         cout << "Step " << outerStep << endl;
 
         // compute contoller step until convergence
-        decomp.calc_controller_step(
+        auto runtimeIter = decomp.calc_controller_step(
             outerStep,
             time,
             rel_err_tol,
@@ -85,6 +87,9 @@ int main()
                 obsVec[domIdx](stepWrap, time, decomp.m_subdomainVec[domIdx]->m_state);
             }
         }
+
+        // runtime observer
+        obs_time(runtimeIter);
 
     }
 

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/compare.py
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/compare.py
@@ -1,26 +1,53 @@
-
+import struct
 import numpy as np
 
 if __name__== "__main__":
-  nx = 30
-  ny = 30
-  fomTotDofs = nx*ny*3
+    nx = 30
+    ny = 30
+    fomTotDofs = nx * ny * 3
 
-  allclose = []
-  for dom_idx in range(4):
-    D = np.fromfile(f"swe_slipWall2d_solution_{dom_idx}.bin")
-    nt = int(np.size(D)/fomTotDofs)
-    D = np.reshape(D, (nt, fomTotDofs))
-    D = D[-1, :]
-    D = np.reshape(D, (nx*ny, 3))
-    h = D[:,0]
-    np.savetxt(f"h_{dom_idx}.txt", h)
+    allclose = []
+    for dom_idx in range(4):
+        D = np.fromfile(f"swe_slipWall2d_solution_{dom_idx}.bin")
+        nt = int(np.size(D) / fomTotDofs)
+        D = np.reshape(D, (nt, fomTotDofs))
+        D = D[-1, :]
+        D = np.reshape(D, (nx * ny, 3))
+        h = D[:, 0]
+        np.savetxt(f"h_{dom_idx}.txt", h)
 
-    goldD = np.loadtxt(f"h_gold_{dom_idx}.txt")
-    assert(h.shape == goldD.shape)
-    assert(np.isnan(h).all() == False)
-    assert(np.isnan(goldD).all() == False)
-    allclose.append(np.allclose(h, goldD, rtol=1e-10, atol=1e-12))
+        goldD = np.loadtxt(f"h_gold_{dom_idx}.txt")
+        assert h.shape == goldD.shape
+        assert np.isnan(h).all() == False
+        assert np.isnan(goldD).all() == False
+        allclose.append(np.allclose(h, goldD, rtol=1e-10, atol=1e-12))
 
-assert all(allclose)
+    assert all(allclose)
+
+    # check runtime file
+    f = open('runtime.bin', 'rb')
+    contents = f.read()
+    nbytes_file = len(contents)
+    assert nbytes_file > 0
+    ndomains = struct.unpack('Q', contents[:8])[0]
+    assert ndomains == 4
+
+    nbytes_read = 8
+    niters = 0
+    while nbytes_read < nbytes_file:
+
+        nsubiters = struct.unpack('Q', contents[nbytes_read:nbytes_read+8])[0]
+        nbytes_read += 8
+        runtime_arr = np.zeros((ndomains, nsubiters), dtype=np.float64)
+
+        for iter_idx in range(nsubiters):
+            runtime_vals = struct.unpack('d'*ndomains, contents[nbytes_read:nbytes_read+8*ndomains])
+            runtime_arr[:, iter_idx] = np.array(runtime_vals, dtype=np.float64)
+            nbytes_read += 8*ndomains
+
+        assert np.amin(runtime_arr) > 0.0
+
+        niters += 1
+
+    assert niters == 500
 

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/main.cc
@@ -47,6 +47,8 @@ int main()
         obsVec[domIdx](::pressio::ode::StepCount(0), 0.0, decomp.m_subdomainVec[domIdx]->m_state);
     }
 
+    RuntimeObserver obs_time("runtime.bin", (*tiling).count());
+
     // solve
     const int numSteps = tf / decomp.m_dtMax;
     double time = 0.0;
@@ -55,7 +57,7 @@ int main()
         cout << "Step " << outerStep << endl;
 
         // compute contoller step until convergence
-        decomp.calc_controller_step(
+        auto runtimeIter = decomp.calc_controller_step(
             outerStep,
             time,
             rel_err_tol,
@@ -73,6 +75,9 @@ int main()
                 obsVec[domIdx](stepWrap, time, decomp.m_subdomainVec[domIdx]->m_state);
             }
         }
+
+        // runtime observer
+        obs_time(runtimeIter);
 
     }
 

--- a/tests_cpp/observer.hpp
+++ b/tests_cpp/observer.hpp
@@ -65,4 +65,51 @@ private:
     const int sampleFreq_ = {};
 };
 
+// This can really only be used with the Schwarz framework,
+//      can't be used with the original PDA stepper
+class RuntimeObserver
+{
+    public:
+        RuntimeObserver(const std::string & f0, int nDomains_in = 1)
+            : timeFile_(f0, std::ios::out | std::ios::binary)
+            , nDomains_(static_cast<std::size_t>(nDomains_in))
+        {
+            // 8-byte file header indicating number of domains
+            timeFile_.write(reinterpret_cast<const char*>(&nDomains_), sizeof(std::size_t));
+        }
+
+        ~RuntimeObserver() { timeFile_.close(); }
+
+        void operator() (std::vector<std::vector<double>> & runtimeVec)
+        {
+            // runtimeVec has dimensions (nDomains, nIters)
+            // record all dimensions with header indicating number of iterations
+
+            // 8-byte record header indicating number of subiterations in this iteration
+            std::size_t niters = runtimeVec[0].size();
+            timeFile_.write(reinterpret_cast<const char*>(&niters), sizeof(std::size_t));
+
+            // unroll iterations, then domain order
+            for (int iterIdx = 0; iterIdx < niters; ++iterIdx) {
+                for (int domIdx = 0; domIdx < nDomains_; ++domIdx) {
+                    timeFile_.write(reinterpret_cast<const char*>(&runtimeVec[domIdx][iterIdx]), sizeof(double));
+                }
+            }
+
+        }
+
+        void operator() (double runtimeVal)
+        {
+            // Overload for handling non-Schwarz input, have to manually time it and pass total runtime
+            // Just write it as if there's one iteration, one domain
+            std::size_t one = static_cast<std::size_t>(1);
+            timeFile_.write(reinterpret_cast<const char*>(&one), sizeof(std::size_t));
+            timeFile_.write(reinterpret_cast<const char*>(&runtimeVal), sizeof(double));
+        }
+
+    private:
+        std::ofstream timeFile_;
+        std::size_t nDomains_;
+};
+
 #endif


### PR DESCRIPTION
Adding an observer utility to track the number of Schwarz iterations and the wall clock run time per Schwarz iteration, per subdomain. Leaving it to the user to aggregate runtime statistics in post-processing.