### PR TITLE
More generic schwarz class

### DIFF
--- a/include/pda-schwarz/custom_bcs.hpp
+++ b/include/pda-schwarz/custom_bcs.hpp
@@ -7,11 +7,11 @@
 #include "pressiodemoapps/euler2d.hpp"
 #include "pressiodemoapps/swe2d.hpp"
 
-using namespace std;
 
-namespace pda = pressiodemoapps;
 
 namespace pdaschwarz{
+
+namespace pda = pressiodemoapps;
 
 enum class BCType {
     HomogNeumann,
@@ -35,7 +35,7 @@ struct BCFunctor
     // This is because BCFunctor has no internal left/right/front/back reference, and
     //  only understand position in graph from GLOBAL (subdomain) cell index
     state_t* m_stateBcs = nullptr;
-    vector<int>* m_graphBcs = nullptr;
+    std::vector<int>* m_graphBcs = nullptr;
 
     BCFunctor(BCType bcSwitch) : m_bcSwitch(bcSwitch){}
 
@@ -43,7 +43,7 @@ struct BCFunctor
         m_stateBcs = stateBcs;
     }
 
-    void setInternalPtr(vector<int>* graphBcs){
+    void setInternalPtr(std::vector<int>* graphBcs){
         m_graphBcs = graphBcs;
     }
 
@@ -53,19 +53,19 @@ struct BCFunctor
         switch(m_bcSwitch)
         {
             case BCType::HomogNeumann:
-                HomogNeumannBC(forward<Args>(args)...);
+                HomogNeumannBC(std::forward<Args>(args)...);
 		        break;
             case BCType::SchwarzDirichlet:
-                SchwarzDirichletBC(forward<Args>(args)...);
+                SchwarzDirichletBC(std::forward<Args>(args)...);
 		        break;
             case BCType::SlipWallVert:
-                SlipWallVertBC(forward<Args>(args)...);
+                SlipWallVertBC(std::forward<Args>(args)...);
                 break;
             case BCType::SlipWallHoriz:
-                SlipWallHorizBC(forward<Args>(args)...);
+                SlipWallHorizBC(std::forward<Args>(args)...);
                 break;
             default:
-                throw runtime_error("Invalid probId for getPhysBCs()");
+	      throw std::runtime_error("Invalid probId for getPhysBCs()");
         };
     }
 
@@ -160,7 +160,7 @@ private:
     {
         // TODO: any way to only check this once? Seems wasteful.
         if ((m_stateBcs == nullptr) || (m_graphBcs == nullptr)) {
-            runtime_error("m_stateBcs or m_graphBcs not set");
+	  std::runtime_error("m_stateBcs or m_graphBcs not set");
         }
 
         const auto bcIndex = (*m_graphBcs)[gRow];
@@ -199,7 +199,7 @@ auto getPhysBCs(pda::Euler2d probId, pda::impl::GhostRelativeLocation rloc)
             break;
 
         default:
-            throw runtime_error("Invalid probId for getPhysBCs()");
+	  throw std::runtime_error("Invalid probId for getPhysBCs()");
 
     }
 }
@@ -219,12 +219,12 @@ auto getPhysBCs(pda::Swe2d probId, pda::impl::GhostRelativeLocation rloc)
                 return BCType::SlipWallHoriz;
             }
             else {
-                throw runtime_error("Unexpected GhostRelativeLocation");
+	      throw std::runtime_error("Unexpected GhostRelativeLocation");
             }
             break;
 
         default:
-            throw runtime_error("Invalid probId for getPhysBCs()");
+	  throw std::runtime_error("Invalid probId for getPhysBCs()");
 
     }
 }

--- a/include/pda-schwarz/rom_utils.hpp
+++ b/include/pda-schwarz/rom_utils.hpp
@@ -11,19 +11,19 @@
 #include <iostream>
 #include "Eigen/Dense"
 
-using namespace std;
+
 
 namespace pdaschwarz {
 
-void checkfile(const string & fileIn){
-    ifstream infile(fileIn);
+void checkfile(const std::string & fileIn){
+    std::ifstream infile(fileIn);
     if (infile.good() == 0) {
-        throw runtime_error("Cannot find file: " + fileIn);
+        throw std::runtime_error("Cannot find file: " + fileIn);
     }
 }
 
 template<class ScalarType>
-auto read_matrix_from_binary(const string & fileName, int numColsToRead) {
+auto read_matrix_from_binary(const std::string & fileName, int numColsToRead) {
 
     using matrix_type = Eigen::Matrix<double, -1, -1, Eigen::ColMajor>;
     using sc_t  = typename matrix_type::Scalar;
@@ -32,8 +32,8 @@ auto read_matrix_from_binary(const string & fileName, int numColsToRead) {
 
     matrix_type M;
 
-    ifstream fin(fileName, ios::in | ios::binary);
-    fin.exceptions(ifstream::failbit | ifstream::badbit);
+    std::ifstream fin(fileName, std::ios::in | std::ios::binary);
+    fin.exceptions(std::ifstream::failbit | std::ifstream::badbit);
 
     // read 2 8-byte integer header, size matrix accordingly
     size_t rows = {};
@@ -48,11 +48,11 @@ auto read_matrix_from_binary(const string & fileName, int numColsToRead) {
     fin.read( (char *) M.data(), nBytes );
 
     if (!fin){
-        cerr << strerror(errno) << endl;
-        throw runtime_error("ERROR READING binary file");
+        std::cerr << strerror(errno) << std::endl;
+        throw std::runtime_error("ERROR READING binary file");
     }
     else{
-        cerr << fin.gcount() << " bytes read\n";
+        std::cerr << fin.gcount() << " bytes read\n";
     }
     fin.close();
     return M;
@@ -60,7 +60,7 @@ auto read_matrix_from_binary(const string & fileName, int numColsToRead) {
 }
 
 template<class ScalarType>
-auto read_vector_from_binary(const string & fileName) {
+auto read_vector_from_binary(const std::string & fileName) {
     auto Vmat = read_matrix_from_binary<ScalarType>(fileName, 1);
     Eigen::VectorXd V = Vmat.col(0);
     return V;

--- a/include/pda-schwarz/schwarz.hpp
+++ b/include/pda-schwarz/schwarz.hpp
@@ -15,7 +15,7 @@
 #include <chrono>
 
 
-using namespace std;
+
 
 namespace pdaschwarz{
 
@@ -25,26 +25,26 @@ namespace pode = pressio::ode;
 using mesh_t = pressiodemoapps::cellcentered_uniform_mesh_eigen_type;
 using euler2d_app_type =
     decltype(pda::create_problem_eigen(
-            declval<mesh_t>(),
-            declval<pressiodemoapps::Euler2d>(),
-            declval<pda::InviscidFluxReconstruction>(),
-            declval<BCFunctor<mesh_t>>(),
-            declval<BCFunctor<mesh_t>>(),
-            declval<BCFunctor<mesh_t>>(),
-            declval<BCFunctor<mesh_t>>(),
+            std::declval<mesh_t>(),
+            std::declval<pressiodemoapps::Euler2d>(),
+            std::declval<pda::InviscidFluxReconstruction>(),
+            std::declval<BCFunctor<mesh_t>>(),
+            std::declval<BCFunctor<mesh_t>>(),
+            std::declval<BCFunctor<mesh_t>>(),
+            std::declval<BCFunctor<mesh_t>>(),
             int(), /* initial condition */
             std::unordered_map<std::string, typename mesh_t::scalar_type>() /* user parameters */
         )
     );
 using swe2d_app_type =
     decltype(pda::create_problem_eigen(
-            declval<mesh_t>(),
-            declval<pressiodemoapps::Swe2d>(),
-            declval<pda::InviscidFluxReconstruction>(),
-            declval<BCFunctor<mesh_t>>(),
-            declval<BCFunctor<mesh_t>>(),
-            declval<BCFunctor<mesh_t>>(),
-            declval<BCFunctor<mesh_t>>(),
+            std::declval<mesh_t>(),
+            std::declval<pressiodemoapps::Swe2d>(),
+            std::declval<pda::InviscidFluxReconstruction>(),
+            std::declval<BCFunctor<mesh_t>>(),
+            std::declval<BCFunctor<mesh_t>>(),
+            std::declval<BCFunctor<mesh_t>>(),
+            std::declval<BCFunctor<mesh_t>>(),
             int(), /* dummy initial */
             std::unordered_map<std::string, typename mesh_t::scalar_type>() /* user parameters */
         )
@@ -60,9 +60,9 @@ public:
     using graph_t = typename app_t::mesh_connectivity_graph_type;
     using state_t = typename app_t::state_type;
 
-    SchwarzDecomp(vector<shared_ptr<SubdomainBase<mesh_t, app_t>>> & subdomains,
-                shared_ptr<const Tiling> tiling,
-                vector<double> & dtVec)
+    SchwarzDecomp(std::vector<std::shared_ptr<SubdomainBase<mesh_t, app_t>>> & subdomains,
+                std::shared_ptr<const Tiling> tiling,
+                std::vector<double> & dtVec)
         : m_tiling(tiling)
         , m_subdomainVec(subdomains)
     {
@@ -92,7 +92,7 @@ public:
 
 private:
 
-    void setup_controller(vector<double> & dtVec)
+    void setup_controller(std::vector<double> & dtVec)
     {
         const auto & tiling = *m_tiling;
 
@@ -102,7 +102,7 @@ private:
             m_dt.resize(tiling.count(), m_dt[0]);
         } else {
             if (m_dt.size() != (size_t) tiling.count()) {
-                cerr << "m_dt.size() must be 1 or ndomains, exiting" << endl;
+                std::cerr << "m_dt.size() must be 1 or ndomains, exiting" << std::endl;
                 exit(-1);
             }
         }
@@ -115,10 +115,10 @@ private:
             if (round(niters) == niters) {
                 m_controlItersVec[domIdx] = int(round(niters));
             } else {
-                cerr << "dt of domain " << domIdx
+                std::cerr << "dt of domain " << domIdx
                 << " (" << m_dt[domIdx]
                 << ") is not an integer divisor of maximum m_dt ("
-                << m_dtMax << ")" << endl;
+                << m_dtMax << ")" << std::endl;
                 exit(-1);
             }
         }
@@ -149,18 +149,19 @@ private:
                 int nyNeigh = m_subdomainVec[neighDomIdx]->ny();
                 int nzNeigh = m_subdomainVec[neighDomIdx]->nz();
 
-                string xerr = "Mesh x-dimension mismatch for domains " + to_string(domIdx) + " v " + to_string(neighDomIdx) + ": " + to_string(nx) + " != " + to_string(nxNeigh);
-                string yerr = "Mesh y-dimension mismatch for domains " + to_string(domIdx) + " v " + to_string(neighDomIdx) + ": " + to_string(ny) + " != " + to_string(nyNeigh);
-                string zerr = "Mesh z-dimension mismatch for domains " + to_string(domIdx) + " v " + to_string(neighDomIdx) + ": " + to_string(nz) + " != " + to_string(nzNeigh);
+		using std::to_string;
+                auto xerr = "Mesh x-dimension mismatch for domains " + to_string(domIdx) + " v " + to_string(neighDomIdx) + ": " + to_string(nx) + " != " + to_string(nxNeigh);
+                auto yerr = "Mesh y-dimension mismatch for domains " + to_string(domIdx) + " v " + to_string(neighDomIdx) + ": " + to_string(ny) + " != " + to_string(nyNeigh);
+                auto zerr = "Mesh z-dimension mismatch for domains " + to_string(domIdx) + " v " + to_string(neighDomIdx) + ": " + to_string(nz) + " != " + to_string(nzNeigh);
 
                 // left and right
                 if ((neighIdx == 0) || (neighIdx == 2)) {
                     if (ny != nyNeigh) {
-                        cerr << yerr << endl;
+                        std::cerr << yerr << std::endl;
                         exit(-1);
                     }
                     if (nz != nzNeigh) {
-                        cerr << zerr << endl;
+                        std::cerr << zerr << std::endl;
                         exit(-1);
                     }
                 }
@@ -168,11 +169,11 @@ private:
                 // front and back
                 if ((neighIdx == 1) || (neighIdx == 3)) {
                     if (nx != nxNeigh) {
-                        cerr << xerr << endl;
+                        std::cerr << xerr << std::endl;
                         exit(-1);
                     }
                     if (nz != nzNeigh) {
-                        cerr << zerr << endl;
+                        std::cerr << zerr << std::endl;
                         exit(-1);
                     }
                 }
@@ -180,11 +181,11 @@ private:
                 // bottom and top
                 if ((neighIdx == 4) || (neighIdx == 5)) {
                     if (nx != nxNeigh) {
-                        cerr << xerr << endl;
+                        std::cerr << xerr << std::endl;
                         exit(-1);
                     }
                     if (ny != nyNeigh) {
-                        cerr << yerr << endl;
+                        std::cerr << yerr << std::endl;
                         exit(-1);
                     }
                 }
@@ -495,14 +496,14 @@ private:
     }
 
     template <class state_t>
-    array<double, 2> calcConvergence(const state_t & state1, const state_t & state2)
+    std::array<double, 2> calcConvergence(const state_t & state1, const state_t & state2)
     {
         // TODO: assumed to be an Eigen state, not sure how to generalize
         // TODO: compute convergence for each variable separately
 
         int numDOF = state1.size();
         if (state2.size() != numDOF) {
-            cerr << "state1 size does not match state2 size, " << numDOF << " vs. " << state2.size() << endl;
+            std::cerr << "state1 size does not match state2 size, " << numDOF << " vs. " << state2.size() << std::endl;
             exit(-1);
         }
 
@@ -524,7 +525,7 @@ private:
             }
         }
 
-        array<double, 2> errArr = {abs_err, rel_err};
+        std::array<double, 2> errArr = {abs_err, rel_err};
         return errArr;
 
     }
@@ -554,7 +555,7 @@ public:
         std::vector<std::vector<double>> iterTime(ndomains);
         while (convergeStep < convergeStepMax) {
 
-            cout << "Schwarz iteration " << convergeStep + 1 << endl;
+            std::cout << "Schwarz iteration " << convergeStep + 1 << std::endl;
 
             for (int domIdx = 0; domIdx < ndomains; ++domIdx) {
 
@@ -615,8 +616,8 @@ public:
             }
             abs_err /= ndomains;
             rel_err /= ndomains;
-            cout << "Average abs err: " << abs_err << endl;
-            cout << "Average rel err: " << rel_err << endl;
+            std::cout << "Average abs err: " << abs_err << std::endl;
+            std::cout << "Average rel err: " << rel_err << std::endl;
             if ((rel_err < rel_err_tol) || (abs_err < abs_err_tol)) {
                 break;
             }
@@ -645,14 +646,14 @@ public:
 public:
 
     int m_dofPerCell;
-    shared_ptr<const Tiling> m_tiling;
-    vector<shared_ptr<SubdomainBase<mesh_t, app_t>>> & m_subdomainVec;
+    std::shared_ptr<const Tiling> m_tiling;
+    std::vector<std::shared_ptr<SubdomainBase<mesh_t, app_t>>> & m_subdomainVec;
     int m_bcStencilSize;
     double m_dtMax;
-    vector<double> m_dt;
-    vector<graph_t> m_exchGraphVec;
-    vector<vector<vector<int>>> m_ghostGraphVec; // 1: subdomain index, 2: edge index, 3: cell index
-    vector<int> m_controlItersVec;
+    std::vector<double> m_dt;
+    std::vector<graph_t> m_exchGraphVec;
+    std::vector<std::vector<std::vector<int>>> m_ghostGraphVec; // 1: subdomain index, 2: edge index, 3: cell index
+    std::vector<int> m_controlItersVec;
 
 };
 }

--- a/include/pda-schwarz/subdomain.hpp
+++ b/include/pda-schwarz/subdomain.hpp
@@ -24,19 +24,54 @@ namespace pls = pressio::linearsolvers;
 namespace prom = pressio::rom;
 namespace plspg = pressio::rom::lspg;
 
+template<class mesh_type, class state_type>
+class SubdomainBase{
+public:
+    using state_t = state_type;
+    using mesh_t = mesh_type;
+
+    virtual int nx() const = 0;
+    virtual int ny() const = 0;
+    virtual int nz() const = 0;
+
+    virtual void allocateStorageForHistory(const int) = 0;
+    virtual void doStep(pode::StepStartAt<double>, pode::StepCount, pode::StepSize<double>) = 0;
+    virtual void storeStateHistory(const int) = 0;
+    virtual void resetStateFromHistory() = 0;
+    virtual void updateFullState() = 0;
+    virtual const mesh_t & getMesh() const = 0;
+    virtual int getDofPerCell() const = 0;
+    virtual state_t * getState() = 0;
+    virtual state_t * getStateBCs() = 0;
+    virtual void setBCPointer(pda::impl::GhostRelativeLocation, state_t * ) = 0;
+    virtual void setBCPointer(pda::impl::GhostRelativeLocation, std::vector<int> *) = 0;
+    virtual state_t & getLastStateInHistory() = 0;
+};
+
+
 template<class mesh_t, class app_type>
-class SubdomainBase
+class SubdomainFOM: public SubdomainBase<mesh_t, typename app_type::state_type>
 {
+public:
+    using app_t   = app_type;
+    using state_t = typename app_t::state_type;
+    using jacob_t = typename app_t::jacobian_type;
+    using base_t = SubdomainBase<mesh_t, state_t>;
+
+    using stepper_t  =
+        decltype(pressio::ode::create_implicit_stepper(pressio::ode::StepScheme(),
+            std::declval<app_t&>())
+        );
+
+    using lin_solver_tag = pressio::linearsolvers::iterative::Bicgstab;
+    using linsolver_t    = pressio::linearsolvers::Solver<lin_solver_tag, jacob_t>;
+    using nonlinsolver_t =
+        decltype( pressio::create_newton_solver( std::declval<stepper_t &>(),
+                            std::declval<linsolver_t&>()) );
 
 public:
-
-    using app_t      = app_type;
-    using state_t    = typename app_t::state_type;
-
-protected:
-
     template<class prob_t>
-    SubdomainBase(const int domainIndex,
+    SubdomainFOM(const int domainIndex,
         const mesh_t & mesh,
         const std::array<int, 3> & meshFullDim,
         BCType bcLeft, BCType bcFront,
@@ -55,94 +90,47 @@ protected:
             BCFunctor<mesh_t>(bcRight), BCFunctor<mesh_t>(bcBack),
             icflag, userParams)))
     , m_state(m_app->initialCondition())
-    {
-        if (order != pressiodemoapps::InviscidFluxReconstruction::FirstOrder){
-            std::runtime_error("Subdomain: inviscid reconstruction must be first oder");
-        }
-
-        init_bc_state(order);
-    }
-
-public:
-
-    int nx() const{ return m_dims[0]; }
-    int ny() const{ return m_dims[1]; }
-    int nz() const{ return m_dims[2]; }
-
-    // we set equal to zero to make these purely virtual
-    virtual void allocateStorageForHistory(const int) = 0;
-    virtual void doStep(pode::StepStartAt<double>, pode::StepCount, pode::StepSize<double>) = 0;
-    virtual void storeStateHistory(const int) = 0;
-    virtual void resetStateFromHistory() = 0;
-    virtual void updateFullState() = 0;
-
-private:
-
-    void init_bc_state(pressiodemoapps::InviscidFluxReconstruction order)
-    {
-        // TODO: can presumably remove this when routines generalized to unstructured format
-        const int bcStencilSize = (pressiodemoapps::reconstructionTypeToStencilSize(order) - 1) / 2;
-        const int bcStencilDof = bcStencilSize * m_app->numDofPerCell();
-        const int numDofStencilBc = 2 * bcStencilDof * (m_dims[0] + m_dims[1] + m_dims[2]);
-        pressiodemoapps::resize(m_stateBCs, numDofStencilBc);
-        m_stateBCs.fill(0.0);
-    }
-
-protected:
-
-    int m_domIdx;
-    std::array<int,3> m_dims = {};
-
-public:
-
-    mesh_t const * m_mesh;
-    std::shared_ptr<app_t> m_app;
-    state_t m_state;
-    state_t m_stateBCs;
-    std::vector<state_t> m_stateHistVec;
-
-};
-
-template<class mesh_t, class app_type>
-class SubdomainFOM: public SubdomainBase<mesh_t, app_type>
-{
-
-public:
-
-    using app_t   = app_type;
-    using state_t = typename app_t::state_type;
-    using jacob_t = typename app_t::jacobian_type;
-
-    using stepper_t  =
-        decltype(pressio::ode::create_implicit_stepper(pressio::ode::StepScheme(),
-            std::declval<app_t&>())
-        );
-
-    using lin_solver_tag = pressio::linearsolvers::iterative::Bicgstab;
-    using linsolver_t    = pressio::linearsolvers::Solver<lin_solver_tag, jacob_t>;
-    using nonlinsolver_t =
-        decltype( pressio::create_newton_solver( std::declval<stepper_t &>(),
-                            std::declval<linsolver_t&>()) );
-
-public:
-
-    template<class prob_t>
-    SubdomainFOM(const int domainIndex,
-        const mesh_t & mesh,
-        const std::array<int, 3> & meshFullDim,
-        BCType bcLeft, BCType bcFront,
-        BCType bcRight, BCType bcBack,
-        prob_t probId,
-        pressio::ode::StepScheme odeScheme,
-        pressiodemoapps::InviscidFluxReconstruction order,
-        const int icflag,
-        const std::unordered_map<std::string, typename mesh_t::scalar_type> & userParams)
-    : SubdomainBase<mesh_t, app_t>::SubdomainBase(domainIndex, mesh, meshFullDim, bcLeft, bcFront, bcRight, bcBack, probId, odeScheme, order, icflag, userParams)
+    // : SubdomainBase<mesh_t>::SubdomainBase(domainIndex, mesh, meshFullDim,
+    // 					   bcLeft, bcFront, bcRight, bcBack,
+    // 					   probId, odeScheme, order, icflag, userParams)
     , m_stepper(pressio::ode::create_implicit_stepper(odeScheme, *(this->m_app)))
     , m_linSolverObj(std::make_shared<linsolver_t>())
     , m_nonlinSolver(pressio::create_newton_solver(m_stepper, *m_linSolverObj))
     {
+        if (order != pressiodemoapps::InviscidFluxReconstruction::FirstOrder){
+            std::runtime_error("Subdomain: inviscid reconstruction must be first oder");
+        }
+	init_bc_state(order);
+
         m_nonlinSolver.setStopTolerance(1e-5);
+    }
+
+    state_t & getLastStateInHistory() final { return m_stateHistVec.back(); }
+
+    void setBCPointer(pda::impl::GhostRelativeLocation grl, state_t * v) final{
+      m_app->setBCPointer(grl, v);
+    }
+    void setBCPointer(pda::impl::GhostRelativeLocation grl, std::vector<int> * v) final{
+      m_app->setBCPointer(grl, v);
+    }
+
+    state_t * getStateBCs() final { return &m_stateBCs; }
+    state_t * getState() final { return &m_state; }
+    int getDofPerCell() const final { return m_app->numDofPerCell(); }
+    const mesh_t & getMesh() const final { return *m_mesh; }
+
+    int nx() const final{ return m_dims[0]; }
+    int ny() const final{ return m_dims[1]; }
+    int nz() const final{ return m_dims[2]; }
+
+    void init_bc_state(pressiodemoapps::InviscidFluxReconstruction order)
+    {
+      // TODO: can presumably remove this when routines generalized to unstructured format
+      const int bcStencilSize = (pressiodemoapps::reconstructionTypeToStencilSize(order) - 1) / 2;
+      const int bcStencilDof = bcStencilSize * m_app->numDofPerCell();
+      const int numDofStencilBc = 2 * bcStencilDof * (m_dims[0] + m_dims[1] + m_dims[2]);
+      pressiodemoapps::resize(m_stateBCs, numDofStencilBc);
+      m_stateBCs.fill(0.0);
     }
 
     void allocateStorageForHistory(const int count) final {
@@ -152,7 +140,10 @@ public:
         }
     }
 
-    void doStep(pode::StepStartAt<double> startTime, pode::StepCount step, pode::StepSize<double> dt) final {
+    void doStep(pode::StepStartAt<double> startTime,
+		pode::StepCount step,
+		pode::StepSize<double> dt) final
+    {
         m_stepper(this->m_state, startTime, step, dt, m_nonlinSolver);
     }
 
@@ -169,20 +160,31 @@ public:
     }
 
 public:
+    int m_domIdx;
+    std::array<int,3> m_dims = {};
+    mesh_t const * m_mesh;
+    std::shared_ptr<app_t> m_app;
+    state_t m_state;
+    state_t m_stateBCs;
+    std::vector<state_t> m_stateHistVec;
 
+    // std::shared_ptr<app_t> m_app;
+    // state_t m_state;
     stepper_t m_stepper;
     std::shared_ptr<linsolver_t> m_linSolverObj;
     nonlinsolver_t m_nonlinSolver;
 
 };
 
-template<class mesh_t, class app_type>
-class SubdomainROM: public SubdomainBase<mesh_t, app_type>
-{
 
+
+template<class mesh_t, class app_type>
+class SubdomainROM: public SubdomainBase<mesh_t, typename app_type::state_type>
+{
     using app_t    = app_type;
     using scalar_t = typename app_t::scalar_type;
     using state_t  = typename app_t::state_type;
+    using base_t = SubdomainBase<mesh_t, state_t>;
 
     using trans_t = decltype(read_vector_from_binary<scalar_t>(std::declval<std::string>()));
     using basis_t = decltype(read_matrix_from_binary<scalar_t>(std::declval<std::string>(), std::declval<int>()));
@@ -190,7 +192,6 @@ class SubdomainROM: public SubdomainBase<mesh_t, app_type>
         state_t>(std::declval<basis_t&&>(), std::declval<trans_t&&>(), true));
 
 public:
-
     template<class prob_t>
     SubdomainROM(const int domainIndex,
         const mesh_t & mesh,
@@ -205,19 +206,62 @@ public:
         const std::string & transRoot,
         const std::string & basisRoot,
         int nmodes)
-    : SubdomainBase<mesh_t, app_t>::SubdomainBase(domainIndex, mesh, meshFullDim, bcLeft, bcFront, bcRight, bcBack, probId, odeScheme, order, icflag, userParams)
+    // : SubdomainBase<mesh_t, app_t>::SubdomainBase(domainIndex, mesh, meshFullDim,
+    // 						  bcLeft, bcFront, bcRight, bcBack,
+    // 						  probId, odeScheme, order, icflag, userParams)
+    : m_domIdx(domainIndex)
+    , m_dims(meshFullDim)
+    , m_mesh(&mesh)
+    , m_app(std::make_shared<app_t>(pressiodemoapps::create_problem_eigen(
+            mesh, probId, order,
+            BCFunctor<mesh_t>(bcLeft),  BCFunctor<mesh_t>(bcFront),
+            BCFunctor<mesh_t>(bcRight), BCFunctor<mesh_t>(bcBack),
+            icflag, userParams)))
+    , m_state(m_app->initialCondition())
     , m_nmodes(nmodes)
     , m_trans(read_vector_from_binary<scalar_t>(transRoot + "_" + std::to_string(domainIndex) + ".bin"))
     , m_basis(read_matrix_from_binary<scalar_t>(basisRoot + "_" + std::to_string(domainIndex) + ".bin", nmodes))
     , m_trialSpace(prom::create_trial_column_subspace<state_t>(std::move(m_basis), std::move(m_trans), true))
     , m_stateReduced(m_trialSpace.createReducedState())
     {
+        if (order != pressiodemoapps::InviscidFluxReconstruction::FirstOrder){
+            std::runtime_error("Subdomain: inviscid reconstruction must be first oder");
+        }
+	init_bc_state(order);
+
         // project initial conditions
         auto u = pressio::ops::clone(this->m_state);
         pressio::ops::update(u, 0., this->m_state, 1, m_trialSpace.translationVector(), -1);
         pressio::ops::product(::pressio::transpose(), 1., m_trialSpace.basis(), u, 0., m_stateReduced);
         m_trialSpace.mapFromReducedState(m_stateReduced, this->m_state);
 
+    }
+
+    state_t & getLastStateInHistory() final { return m_stateHistVec.back(); }
+    void setBCPointer(pda::impl::GhostRelativeLocation grl, state_t * v) final{
+      m_app->setBCPointer(grl, v);
+    }
+    void setBCPointer(pda::impl::GhostRelativeLocation grl, std::vector<int> * v) final{
+      m_app->setBCPointer(grl, v);
+    }
+
+    state_t * getStateBCs() final { return &m_stateBCs; }
+    state_t * getState() final { return &m_state; }
+    int getDofPerCell() const final { return m_app->numDofPerCell(); }
+    const mesh_t & getMesh() const final { return *m_mesh; }
+
+    int nx() const final{ return m_dims[0]; }
+    int ny() const final{ return m_dims[1]; }
+    int nz() const final{ return m_dims[2]; }
+
+    void init_bc_state(pressiodemoapps::InviscidFluxReconstruction order)
+    {
+      // TODO: can presumably remove this when routines generalized to unstructured format
+      const int bcStencilSize = (pressiodemoapps::reconstructionTypeToStencilSize(order) - 1) / 2;
+      const int bcStencilDof = bcStencilSize * m_app->numDofPerCell();
+      const int numDofStencilBc = 2 * bcStencilDof * (m_dims[0] + m_dims[1] + m_dims[2]);
+      pressiodemoapps::resize(m_stateBCs, numDofStencilBc);
+      m_stateBCs.fill(0.0);
     }
 
     void allocateStorageForHistory(const int count){
@@ -242,6 +286,13 @@ public:
     }
 
 protected:
+    int m_domIdx;
+    std::array<int,3> m_dims = {};
+    mesh_t const * m_mesh;
+    std::shared_ptr<app_t> m_app;
+    state_t m_state;
+    state_t m_stateBCs;
+    std::vector<state_t> m_stateHistVec;
 
     int m_nmodes;
     trans_t m_trans;
@@ -307,7 +358,6 @@ public:
     }
 
 private:
-
     problem_t m_problem;
     stepper_t m_stepper;
     std::shared_ptr<linsolver_t> m_linSolverObj;
@@ -414,7 +464,7 @@ auto create_subdomains(const std::vector<std::string> & meshPaths,
     // add checks that vectors are all same size?
 
     // using subdomain_t = Subdomain<prob_t, mesh_t, app_t>;
-    using subdomain_t = SubdomainBase<mesh_t, app_t>;
+    using subdomain_t = SubdomainBase<mesh_t, typename app_t::state_type>;
     std::vector<std::shared_ptr<subdomain_t>> result;
 
     const int ndomX = tiling.countX();

--- a/include/pda-schwarz/tiling.hpp
+++ b/include/pda-schwarz/tiling.hpp
@@ -10,7 +10,7 @@
 #include <fstream>
 #include <sstream>
 
-using namespace std;
+
 
 namespace pdaschwarz{
 
@@ -19,13 +19,13 @@ namespace pdaschwarz{
 //
 struct Tiling
 {
-    explicit Tiling(const string & meshRoot){
+    explicit Tiling(const std::string & meshRoot){
         read_domain_info(meshRoot);
         calc_neighbor_dims();
     }
 
     void describe(){
-        cout << " Tiling info: "
+        std::cout << " Tiling info: "
             << " ndomX = " << m_ndomX
             << " ndomY = " << m_ndomY
             << " ndomZ = " << m_ndomZ
@@ -44,12 +44,12 @@ struct Tiling
 
 private:
 
-    void read_domain_info(const string & meshRoot)
+    void read_domain_info(const std::string & meshRoot)
     {
         const auto inFile = meshRoot + "/info_domain.dat";
-        ifstream foundFile(inFile);
+        std::ifstream foundFile(inFile);
         if (!foundFile) {
-            cout << "file not found " << inFile << endl;
+            std::cout << "file not found " << inFile << std::endl;
             exit(EXIT_FAILURE);
         }
 
@@ -57,43 +57,43 @@ private:
         m_ndomX = 1;
         m_ndomY = 1;
         m_ndomZ = 1;
-        ifstream source( inFile, ios_base::in);
-        string line;
+        std::ifstream source( inFile, std::ios_base::in);
+        std::string line;
         while (getline(source, line)) {
-            istringstream ss(line);
-            string colVal;
+	    std::istringstream ss(line);
+            std::string colVal;
             ss >> colVal;
 
             if (colVal == "dim"){
                 ss >> colVal;
                 m_dim = stoi(colVal);
-                if (m_dim < 1) throw runtime_error("dim must be >= 1");
+                if (m_dim < 1) throw std::runtime_error("dim must be >= 1");
             }
             else if (colVal == "ndomX"){
                 ss >> colVal;
                 m_ndomX = stoi(colVal);
-                if (m_ndomX < 1) throw runtime_error("ndomX must be >= 1");
+                if (m_ndomX < 1) throw std::runtime_error("ndomX must be >= 1");
             }
 
             else if (colVal == "ndomY"){
                 ss >> colVal;
                 m_ndomY = stoi(colVal);
-                if (m_ndomY < 1) throw runtime_error("ndomY must be >= 1");
+                if (m_ndomY < 1) throw std::runtime_error("ndomY must be >= 1");
             }
             else if (colVal == "ndomZ"){
                 ss >> colVal;
                 m_ndomZ = stoi(colVal);
-                if (m_ndomZ < 1) throw runtime_error("ndomZ must be >= 1");
+                if (m_ndomZ < 1) throw std::runtime_error("ndomZ must be >= 1");
             }
 
             else if (colVal == "overlap"){
                 ss >> colVal;
                 m_overlap = stoi(colVal);
-                if (m_overlap < 0) throw runtime_error("overlap must be > 0");
+                if (m_overlap < 0) throw std::runtime_error("overlap must be > 0");
 
                 // has to be an even number for simplicity, can change later
                 if (m_overlap % 2) {
-                    cerr << "overlap must be an even number" << endl;
+                    std::cerr << "overlap must be an even number" << std::endl;
                     exit(-1);
                 }
             }
@@ -106,7 +106,7 @@ private:
     {
         // determine neighboring domain IDs
         int maxDomNeighbors = 2 * m_dim;
-        m_exchDomIdVec.resize(m_ndomains, vector<int>(maxDomNeighbors, -1));
+        m_exchDomIdVec.resize(m_ndomains, std::vector<int>(maxDomNeighbors, -1));
 
         for (int domIdx = 0; domIdx < m_ndomains; ++domIdx) {
             // subdomain indices
@@ -172,7 +172,7 @@ private:
     int m_overlap = {};
     int m_ndomains = {};
 
-    vector<vector<int>> m_exchDomIdVec;
+    std::vector<std::vector<int>> m_exchDomIdVec;
 };
 
 }

--- a/tests_cpp/eigen_2d_euler_riemann_implicit_schwarz/main.cc
+++ b/tests_cpp/eigen_2d_euler_riemann_implicit_schwarz/main.cc
@@ -35,7 +35,8 @@ int main()
     // tiling, meshes, and decomposition
     auto tiling = std::make_shared<pdas::Tiling>(meshRoot);
     auto [meshPaths, meshObjs] = pdas::create_meshes(meshRoot, tiling->count());
-    auto subdomains = pdas::create_subdomains<app_t>(meshPaths, meshObjs, *tiling, probId, scheme, order, icFlag);
+    auto subdomains = pdas::create_subdomains<app_t>(meshPaths, meshObjs, *tiling,
+						     probId, scheme, order, icFlag);
     pdas::SchwarzDecomp decomp(subdomains, tiling, dt);
 
     // observer
@@ -44,7 +45,7 @@ int main()
     vector<obs_t> obsVec((*decomp.m_tiling).count());
     for (int domIdx = 0; domIdx < (*decomp.m_tiling).count(); ++domIdx) {
         obsVec[domIdx] = obs_t(obsRoot + "_" + to_string(domIdx) + ".bin", obsFreq);
-        obsVec[domIdx](::pressio::ode::StepCount(0), 0.0, decomp.m_subdomainVec[domIdx]->m_state);
+        obsVec[domIdx](::pressio::ode::StepCount(0), 0.0, *decomp.m_subdomainVec[domIdx]->getState());
     }
 
     RuntimeObserver obs_time("runtime.bin", (*tiling).count());
@@ -72,7 +73,7 @@ int main()
         if ((outerStep % obsFreq) == 0) {
             const auto stepWrap = pode::StepCount(outerStep);
             for (int domIdx = 0; domIdx < (*decomp.m_tiling).count(); ++domIdx) {
-                obsVec[domIdx](stepWrap, time, decomp.m_subdomainVec[domIdx]->m_state);
+	      obsVec[domIdx](stepWrap, time, *decomp.m_subdomainVec[domIdx]->getState());
             }
         }
 

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/main.cc
@@ -56,7 +56,7 @@ int main()
     vector<obs_t> obsVec((*decomp.m_tiling).count());
     for (int domIdx = 0; domIdx < (*decomp.m_tiling).count(); ++domIdx) {
         obsVec[domIdx] = obs_t(obsRoot + "_" + to_string(domIdx) + ".bin", obsFreq);
-        obsVec[domIdx](::pressio::ode::StepCount(0), 0.0, decomp.m_subdomainVec[domIdx]->m_state);
+        obsVec[domIdx](::pressio::ode::StepCount(0), 0.0, *decomp.m_subdomainVec[domIdx]->getState());
     }
 
     RuntimeObserver obs_time("runtime.bin", (*tiling).count());
@@ -84,7 +84,7 @@ int main()
         if ((outerStep % obsFreq) == 0) {
             const auto stepWrap = pode::StepCount(outerStep);
             for (int domIdx = 0; domIdx < (*decomp.m_tiling).count(); ++domIdx) {
-                obsVec[domIdx](stepWrap, time, decomp.m_subdomainVec[domIdx]->m_state);
+	      obsVec[domIdx](stepWrap, time, *decomp.m_subdomainVec[domIdx]->getState());
             }
         }
 

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/main.cc
@@ -44,7 +44,7 @@ int main()
     vector<obs_t> obsVec((*decomp.m_tiling).count());
     for (int domIdx = 0; domIdx < (*decomp.m_tiling).count(); ++domIdx) {
         obsVec[domIdx] = obs_t(obsRoot + "_" + to_string(domIdx) + ".bin", obsFreq);
-        obsVec[domIdx](::pressio::ode::StepCount(0), 0.0, decomp.m_subdomainVec[domIdx]->m_state);
+        obsVec[domIdx](::pressio::ode::StepCount(0), 0.0, *decomp.m_subdomainVec[domIdx]->getState());
     }
 
     RuntimeObserver obs_time("runtime.bin", (*tiling).count());
@@ -72,7 +72,7 @@ int main()
         if ((outerStep % obsFreq) == 0) {
             const auto stepWrap = pode::StepCount(outerStep);
             for (int domIdx = 0; domIdx < (*decomp.m_tiling).count(); ++domIdx) {
-                obsVec[domIdx](stepWrap, time, decomp.m_subdomainVec[domIdx]->m_state);
+	      obsVec[domIdx](stepWrap, time, *decomp.m_subdomainVec[domIdx]->getState());
             }
         }
 


### PR DESCRIPTION
this works (tests pass) but it is just a prototype idea 
depends on #15 

the main idea is to do this:
```

template<class mesh_type, class state_type>
class SubdomainBase{
public:
    using state_t = state_type;
    using mesh_t = mesh_type;

    virtual int nx() const = 0;
    virtual int ny() const = 0;
    virtual int nz() const = 0;

    virtual void allocateStorageForHistory(const int) = 0;
    virtual void doStep(pode::StepStartAt<double>, pode::StepCount, pode::StepSize<double>) = 0;
    virtual void storeStateHistory(const int) = 0;
    virtual void resetStateFromHistory() = 0;
    virtual void updateFullState() = 0;
    virtual const mesh_t & getMesh() const = 0;
    virtual int getDofPerCell() const = 0;
    virtual state_t * getState() = 0;
    virtual state_t * getStateBCs() = 0;
    virtual void setBCPointer(pda::impl::GhostRelativeLocation, state_t * ) = 0;
    virtual void setBCPointer(pda::impl::GhostRelativeLocation, std::vector<int> *) = 0;
    virtual state_t & getLastStateInHistory() = 0;
};
```
obviously this has to be improved and there are pros and cons to this

in the end, we have to think about designing a solution that could work for a generic solver/subdomain vs making it work for demoapps