### PR TITLE
Individual subdomain flux orders and time schemes

### DIFF
--- a/include/pda-schwarz/schwarz.hpp
+++ b/include/pda-schwarz/schwarz.hpp
@@ -715,34 +715,34 @@ public:
                 }
             }
 
-        auto task1 = [&](int domIdx) {
-            domainControlLoop(domIdx, currentTime, outerStep, errs(domIdx, 0));
-        };
-        pool.detach_loop<int>(0, ndomains, task1);
-        pool.wait();
+            auto task1 = [&](int domIdx) {
+                domainControlLoop(domIdx, currentTime, outerStep, errs(domIdx, 0));
+            };
+            pool.detach_loop<int>(0, ndomains, task1);
+            pool.wait();
 
-        for(int i = 0 ; i < ndomains ; ++i){
-            m_ae += errs(i, 0).m_absolute;
-            m_re += errs(i, 0).m_relative;
-        }
-        m_re /= double(ndomains);
-        m_ae /= double(ndomains);
-        std::cout << "Schwarz iteration " << convergeStep + 1 << "\n";
-        std::cout << "Average abs err: " << m_ae << "\n";
-        std::cout << "Average rel err: " << m_re << '\n';
+            for(int i = 0 ; i < ndomains ; ++i){
+                m_ae += errs(i, 0).m_absolute;
+                m_re += errs(i, 0).m_relative;
+            }
+            m_re /= double(ndomains);
+            m_ae /= double(ndomains);
+            std::cout << "Schwarz iteration " << convergeStep + 1 << "\n";
+            std::cout << "Average abs err: " << m_ae << "\n";
+            std::cout << "Average rel err: " << m_re << '\n';
 
-        if ((m_re < rel_err_tol) || (m_ae < abs_err_tol)) {
-            break;
-        }
-        convergeStep++;
+            if ((m_re < rel_err_tol) || (m_ae < abs_err_tol)) {
+                break;
+            }
+            convergeStep++;
 
-        auto task = [&](const int domIdx){ broadcast_bcState(domIdx); };
-        pool.detach_loop<int>(0, ndomains, task);
-        pool.wait();
+            auto task = [&](const int domIdx){ broadcast_bcState(domIdx); };
+            pool.detach_loop<int>(0, ndomains, task);
+            pool.wait();
 
-        auto taskreset = [&](const int domIdx){ m_subdomainVec[domIdx]->resetStateFromHistory(); };
-        pool.detach_loop<int>(0, ndomains, taskreset);
-        pool.wait();
+            auto taskreset = [&](const int domIdx){ m_subdomainVec[domIdx]->resetStateFromHistory(); };
+            pool.detach_loop<int>(0, ndomains, taskreset);
+            pool.wait();
         }
 
         return convergeStep;

--- a/tests_cpp/eigen_2d_euler_riemann_implicit_schwarz/main.cc
+++ b/tests_cpp/eigen_2d_euler_riemann_implicit_schwarz/main.cc
@@ -17,13 +17,13 @@ int main()
     // problem definition
     const auto probId = pda::Euler2d::Riemann;
 #ifdef USE_WENO5
-    const auto order   = pda::InviscidFluxReconstruction::Weno5;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::Weno5);
 #elif defined USE_WENO3
-    const auto order   = pda::InviscidFluxReconstruction::Weno3;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::Weno3);
 #else
-    const auto order   = pda::InviscidFluxReconstruction::FirstOrder;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::FirstOrder);
 #endif
-    const auto scheme = pode::StepScheme::CrankNicolson;
+    std::vector<pode::StepScheme> schemeVec(4, pode::StepScheme::CrankNicolson);
     const int icFlag = 2;
     using app_t = pdas::euler2d_app_type;
 
@@ -41,7 +41,7 @@ int main()
     auto [meshObjs, meshPaths] = pdas::create_meshes(meshRoot, tiling->count());
     auto subdomains = pdas::create_subdomains<app_t>(
         meshObjs, *tiling,
-		probId, scheme, order, icFlag);
+		probId, schemeVec, orderVec, icFlag);
     pdas::SchwarzDecomp decomp(subdomains, tiling, dt);
 
     // observer

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_hproms_schwarz/lspg/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_hproms_schwarz/lspg/main.cc
@@ -20,13 +20,13 @@ int main()
     // problem definition
     const auto probId = pda::Swe2d::CustomBCs;
 #ifdef USE_WENO5
-    const auto order   = pda::InviscidFluxReconstruction::Weno5;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::Weno5);
 #elif defined USE_WENO3
-    const auto order   = pda::InviscidFluxReconstruction::Weno3;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::Weno3);
 #else
-    const auto order   = pda::InviscidFluxReconstruction::FirstOrder;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::FirstOrder);
 #endif
-    const auto scheme = pode::StepScheme::BDF1;
+    std::vector<pode::StepScheme> schemeVec(4, pode::StepScheme::BDF1);
     const int icFlag  = 1;
     using app_t = pdas::swe2d_app_type;
 
@@ -53,7 +53,7 @@ int main()
         meshPathsHyper.emplace_back(meshRootHyper + "/domain_" + std::to_string(domIdx));
     }
     auto subdomains = pdas::create_subdomains<app_t>(
-        meshObjsFull, *tiling, probId, scheme, order,
+        meshObjsFull, *tiling, probId, schemeVec, orderVec,
         domFlagVec, transRoot, basisRoot, nmodesVec, icFlag,
         meshPathsHyper);
     pdas::SchwarzDecomp decomp(subdomains, tiling, dt);

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_mixed_schwarz/lspg/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_mixed_schwarz/lspg/main.cc
@@ -20,13 +20,13 @@ int main()
     // problem definition
     const auto probId = pda::Swe2d::CustomBCs;
 #ifdef USE_WENO5
-    const auto order   = pda::InviscidFluxReconstruction::Weno5;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::Weno5);
 #elif defined USE_WENO3
-    const auto order   = pda::InviscidFluxReconstruction::Weno3;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::Weno3);
 #else
-    const auto order   = pda::InviscidFluxReconstruction::FirstOrder;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::FirstOrder);
 #endif
-    const auto scheme = pode::StepScheme::BDF1;
+    std::vector<pode::StepScheme> schemeVec(4, pode::StepScheme::BDF1);
     const int icFlag  = 1;
     using app_t = pdas::swe2d_app_type;
 
@@ -53,7 +53,7 @@ int main()
         meshPathsHyper.emplace_back(meshRootHyper + "/domain_" + std::to_string(domIdx));
     }
     auto subdomains = pdas::create_subdomains<app_t>(
-        meshObjsFull, *tiling, probId, scheme, order,
+        meshObjsFull, *tiling, probId, schemeVec, orderVec,
         domFlagVec, transRoot, basisRoot, nmodesVec, icFlag,
         meshPathsHyper);
     pdas::SchwarzDecomp decomp(subdomains, tiling, dt);

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/main.cc
@@ -18,13 +18,13 @@ int main()
     // problem definition
     const auto probId = pda::Swe2d::CustomBCs;
 #ifdef USE_WENO5
-    const auto order   = pda::InviscidFluxReconstruction::Weno5;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::Weno5);
 #elif defined USE_WENO3
-    const auto order   = pda::InviscidFluxReconstruction::Weno3;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::Weno3);
 #else
-    const auto order   = pda::InviscidFluxReconstruction::FirstOrder;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::FirstOrder);
 #endif
-    const auto scheme = pode::StepScheme::BDF1;
+    std::vector<pode::StepScheme> schemeVec(4, pode::StepScheme::BDF1);
     const int icFlag  = 1;
     using app_t = pdas::swe2d_app_type;
 
@@ -47,7 +47,7 @@ int main()
     auto tiling = std::make_shared<pdas::Tiling>(meshRoot);
     auto [meshObjs, meshPaths] = pdas::create_meshes(meshRoot, tiling->count());
     auto subdomains = pdas::create_subdomains<app_t>(
-        meshObjs, *tiling, probId, scheme, order,
+        meshObjs, *tiling, probId, schemeVec, orderVec,
         domFlagVec, transRoot, basisRoot, nmodesVec, icFlag);
     pdas::SchwarzDecomp decomp(subdomains, tiling, dt);
 

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/main.cc
@@ -17,13 +17,13 @@ int main()
     // problem definition
     const auto probId = pda::Swe2d::CustomBCs;
 #ifdef USE_WENO5
-    const auto order   = pda::InviscidFluxReconstruction::Weno5;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::Weno5);
 #elif defined USE_WENO3
-    const auto order   = pda::InviscidFluxReconstruction::Weno3;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::Weno3);
 #else
-    const auto order   = pda::InviscidFluxReconstruction::FirstOrder;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(4, pda::InviscidFluxReconstruction::FirstOrder);
 #endif
-    const auto scheme = pode::StepScheme::BDF1;
+    std::vector<pode::StepScheme> schemeVec(4, pode::StepScheme::BDF1);
     const int icFlag = 1;
     using app_t = pdas::swe2d_app_type;
 
@@ -41,7 +41,7 @@ int main()
     auto [meshObjs, meshPaths] = pdas::create_meshes(meshRoot, tiling->count());
     auto subdomains = pdas::create_subdomains<app_t>(
         meshObjs, *tiling,
-        probId, scheme, order, icFlag);
+        probId, schemeVec, orderVec, icFlag);
     pdas::SchwarzDecomp decomp(subdomains, tiling, dt);
 
     // observer

--- a/tests_cpp/parallel/eigen_2d_swe_slip_wall_implicit_hproms_schwarz_parallel/lspg/main.cc
+++ b/tests_cpp/parallel/eigen_2d_swe_slip_wall_implicit_hproms_schwarz_parallel/lspg/main.cc
@@ -27,19 +27,19 @@ int main(int argc, char *argv[])
     const auto probId = pda::Swe2d::CustomBCs;
 #ifdef USE_WENO5
     static_assert(false);
-    const auto order   = pda::InviscidFluxReconstruction::Weno5;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(12, pda::InviscidFluxReconstruction::Weno5);
 #elif defined USE_WENO3
     std::string outRoot = "./weno3" + dir_suffix;
-    const auto order   = pda::InviscidFluxReconstruction::Weno3;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(12, pda::InviscidFluxReconstruction::Weno3);
 #else
     std::string outRoot = "./firstorder" + dir_suffix;
-    const auto order   = pda::InviscidFluxReconstruction::FirstOrder;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(12, pda::InviscidFluxReconstruction::FirstOrder);
 #endif
     std::string obsRoot = outRoot + "/swe_slipWall2d_solution";
     std::string meshRootFull = outRoot + "/full_mesh_decomp";
     std::string meshRootHyper = outRoot + "/sample_mesh_decomp";
 
-    const auto scheme = pode::StepScheme::BDF1;
+    std::vector<pode::StepScheme> schemeVec(12, pode::StepScheme::BDF1);
     const int icFlag = 1;
     using app_t = pdas::swe2d_app_type;
 
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
         meshPathsHyper.emplace_back(meshRootHyper + "/domain_" + std::to_string(domIdx));
     }
     auto subdomains = pdas::create_subdomains<app_t>(
-        meshObjsFull, *tiling, probId, scheme, order,
+        meshObjsFull, *tiling, probId, schemeVec, orderVec,
         domFlagVec, transRoot, basisRoot, nmodesVec, icFlag, meshPathsHyper);
     pdas::SchwarzDecomp decomp(subdomains, tiling, dt);
 

--- a/tests_cpp/parallel/eigen_2d_swe_slip_wall_implicit_schwarz_parallel/main.cc
+++ b/tests_cpp/parallel/eigen_2d_swe_slip_wall_implicit_schwarz_parallel/main.cc
@@ -26,18 +26,18 @@ int main(int argc, char *argv[])
     const auto probId = pda::Swe2d::CustomBCs;
 #ifdef USE_WENO5
     static_assert(false);
-    const auto order   = pda::InviscidFluxReconstruction::Weno5;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(12, pda::InviscidFluxReconstruction::Weno5);
 #elif defined USE_WENO3
     std::string outRoot = "./weno3" + dir_suffix;
-    const auto order   = pda::InviscidFluxReconstruction::Weno3;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(12, pda::InviscidFluxReconstruction::Weno3);
 #else
     std::string outRoot = "./firstorder" + dir_suffix;
-    const auto order   = pda::InviscidFluxReconstruction::FirstOrder;
+    std::vector<pda::InviscidFluxReconstruction> orderVec(12, pda::InviscidFluxReconstruction::FirstOrder);
 #endif
     std::string obsRoot = outRoot + "/swe_slipWall2d_solution";
     std::string meshRoot = outRoot + "/mesh";
 
-    const auto scheme = pode::StepScheme::BDF1;
+    std::vector<pode::StepScheme> schemeVec(12, pode::StepScheme::BDF1);
     const int icFlag = 1;
     using app_t = pdas::swe2d_app_type;
 
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
     auto tiling = std::make_shared<pdas::Tiling>(meshRoot);
     auto [meshes, meshPaths] = pdas::create_meshes(meshRoot, tiling->count());
     auto subdomains = pdas::create_subdomains<app_t>(
-        meshes, *tiling, probId, scheme, order, icFlag);
+        meshes, *tiling, probId, schemeVec, orderVec, icFlag);
     pdas::SchwarzDecomp decomp(subdomains, tiling, dt);
 
     // observers


### PR DESCRIPTION
Enable setting individual flux orders and time schemes for each subdomain. It frankly doesn't seem to work very well, but this may largely be due to testing it on really coarse meshes.