### PR TITLE
correct issues with runtime observers

### DIFF
--- a/include/pda-schwarz/schwarz.hpp
+++ b/include/pda-schwarz/schwarz.hpp
@@ -745,7 +745,8 @@ public:
             pool.wait();
         }
 
-        return convergeStep;
+        // breaks before counter increments
+        return convergeStep + 1;
     }
 
     int additive_step(int outerStep, double currentTime,
@@ -831,7 +832,8 @@ public:
             }
         } // convergence loop
 
-        return convergeStep;
+        // returns before counter increments
+        return convergeStep + 1;
     }
 
 
@@ -888,7 +890,8 @@ public:
 
         } // convergence loop
 
-        return convergeStep;
+        // break is before counter increments
+        return convergeStep + 1;
     }
 
 private:

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_mixed_schwarz/lspg/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_mixed_schwarz/lspg/main.cc
@@ -86,11 +86,11 @@ int main()
             abs_err_tol,
             convergeStepMax
         );
-        const auto runtimeEnd = std::chrono::high_resolution_clock::now();
-        const auto nsDuration = std::chrono::duration_cast<std::chrono::nanoseconds>(runtimeEnd - runtimeStart);
-        const double secsElapsed = static_cast<double>(nsDuration.count()) * 1e-9;
-
         time += decomp.m_dtMax;
+
+        const auto runtimeEnd = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double, std::milli> duration = runtimeEnd - runtimeStart;
+        obs_time(duration.count() * 1e-3, numSubiters);
 
         // output observer
         if ((outerStep % obsFreq) == 0) {
@@ -99,10 +99,6 @@ int main()
                 obsVec[domIdx](stepWrap, time, *decomp.m_subdomainVec[domIdx]->getStateFull());
             }
         }
-
-        // runtime observer
-        obs_time(secsElapsed, numSubiters);
-
     }
 
     return 0;

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_nonoverlap_dd/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_nonoverlap_dd/main.cc
@@ -73,8 +73,8 @@ int main()
             convergeStepMax
         );
         const auto runtimeEnd = std::chrono::high_resolution_clock::now();
-        const auto nsDuration = std::chrono::duration_cast<std::chrono::nanoseconds>(runtimeEnd - runtimeStart);
-        const double secsElapsed = static_cast<double>(nsDuration.count()) * 1e-9;
+        std::chrono::duration<double, std::milli> duration = runtimeEnd - runtimeStart;
+        obs_time(duration.count() * 1e-3, numSubiters);
 
         time += decomp.m_dtMax;
 
@@ -85,10 +85,6 @@ int main()
                 obsVec[domIdx](stepWrap, time, *decomp.m_subdomainVec[domIdx]->getStateFull());
             }
         }
-
-        // runtime observer
-        obs_time(secsElapsed, numSubiters);
-
     }
 
   return 0;

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms/lspg/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms/lspg/main.cc
@@ -82,9 +82,8 @@ int main()
     auto runtimeStart = std::chrono::high_resolution_clock::now();
     pode::advance_n_steps(stepper, reducedState, 0.0, dt, Nsteps, Obs, solver);
     auto runtimeEnd = std::chrono::high_resolution_clock::now();
-    auto nsElapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(runtimeEnd - runtimeStart).count();
-    double secElapsed = static_cast<double>(nsElapsed) * 1e-9;
-    Obs_run(secElapsed);
+    std::chrono::duration<double, std::milli> duration = runtimeEnd - runtimeStart;
+    Obs_run(duration.count() * 1e-3);
 
     pressio::log::finalize();
     return 0;

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_roms_schwarz/lspg/main.cc
@@ -80,8 +80,8 @@ int main()
             convergeStepMax
         );
         const auto runtimeEnd = std::chrono::high_resolution_clock::now();
-        const auto nsDuration = std::chrono::duration_cast<std::chrono::nanoseconds>(runtimeEnd - runtimeStart);
-        const double secsElapsed = static_cast<double>(nsDuration.count()) * 1e-9;
+        std::chrono::duration<double, std::milli> duration = runtimeEnd - runtimeStart;
+        obs_time(duration.count() * 1e-3, numSubiters);
 
         time += decomp.m_dtMax;
 
@@ -92,10 +92,6 @@ int main()
                 obsVec[domIdx](stepWrap, time, *decomp.m_subdomainVec[domIdx]->getStateFull());
             }
         }
-
-        // runtime observer
-        obs_time(secsElapsed, numSubiters);
-
     }
 
     return 0;

--- a/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/main.cc
+++ b/tests_cpp/eigen_2d_swe_slip_wall_implicit_schwarz/main.cc
@@ -73,8 +73,8 @@ int main()
             convergeStepMax
         );
         const auto runtimeEnd = std::chrono::high_resolution_clock::now();
-        const auto nsDuration = std::chrono::duration_cast<std::chrono::nanoseconds>(runtimeEnd - runtimeStart);
-        const double secsElapsed = static_cast<double>(nsDuration.count()) * 1e-9;
+        std::chrono::duration<double, std::milli> duration = runtimeEnd - runtimeStart;
+        obs_time(duration.count() * 1e-3, numSubiters);
 
         time += decomp.m_dtMax;
 
@@ -85,10 +85,6 @@ int main()
                 obsVec[domIdx](stepWrap, time, *decomp.m_subdomainVec[domIdx]->getStateFull());
             }
         }
-
-        // runtime observer
-        obs_time(secsElapsed, numSubiters);
-
     }
 
   return 0;

--- a/tests_cpp/parallel/eigen_2d_swe_slip_wall_implicit_large/main.cc
+++ b/tests_cpp/parallel/eigen_2d_swe_slip_wall_implicit_large/main.cc
@@ -48,9 +48,8 @@ int main()
     auto runtimeStart = std::chrono::high_resolution_clock::now();
     pressio::ode::advance_n_steps(stepperObj, state, 0., dt, Nsteps, Obs, NonLinSolver);
     auto runtimeEnd = std::chrono::high_resolution_clock::now();
-    auto nsElapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(runtimeEnd - runtimeStart).count();
-    double secElapsed = static_cast<double>(nsElapsed) * 1e-9;
-    Obs_run(secElapsed);
+    std::chrono::duration<double, std::milli> duration = runtimeEnd - runtimeStart;
+    Obs_run(duration.count() * 1e-3);
 
     pressio::log::finalize();
     return 0;

--- a/tests_cpp/parallel/eigen_2d_swe_slip_wall_implicit_schwarz_parallel/main.cc
+++ b/tests_cpp/parallel/eigen_2d_swe_slip_wall_implicit_schwarz_parallel/main.cc
@@ -91,18 +91,14 @@ int main(int argc, char *argv[])
             auto runtimeStart = std::chrono::high_resolution_clock::now();
         }
         auto numSubiters = decomp.additive_step(outerStep, simultime, rel_err_tol, abs_err_tol, convergeStepMax);
+        simultime += decomp.m_dtMax;
 #pragma omp barrier
 #pragma omp master
         {
             const auto runtimeEnd = std::chrono::high_resolution_clock::now();
-            const auto nsDuration = std::chrono::duration_cast<std::chrono::nanoseconds>(runtimeEnd - runtimeStart);
-            secsElapsed = static_cast<double>(nsDuration.count());
-        }
-        simultime += decomp.m_dtMax;
+            std::chrono::duration<double, std::milli> duration = runtimeEnd - runtimeStart;
+            obs_time(duration.count() * 1e-3, numSubiters);
 
-#pragma omp barrier
-#pragma omp master
-        {
             // output observer
             if ((outerStep % obsFreq) == 0) {
                 const auto stepWrap = pode::StepCount(outerStep);
@@ -110,7 +106,6 @@ int main(int argc, char *argv[])
                     obsVec[domIdx](stepWrap, time, *decomp.m_subdomainVec[domIdx]->getStateFull());
                 }
             }
-            obs_time(secsElapsed, numSubiters);
         }
 
     }


### PR DESCRIPTION
Runtime observers were incorrectly reporting the number of Schwarz subiterations (issue in `schwarz.hpp`), and parallel implementation was reporting the runtime incorrectly.